### PR TITLE
Use Java 7 for now

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -216,7 +216,7 @@
                     <configuration>
                         <use>false</use>
                         <links>
-                            <link>http://docs.oracle.com/javase/8/docs/api/</link>
+                            <link>http://docs.oracle.com/javase/7/docs/api/</link>
                         </links>
                         <stylesheet>java</stylesheet>
                     </configuration>


### PR DESCRIPTION
As mentioned by @mpkorstanje in [cucumber-jvm PR #1494](https://github.com/cucumber/cucumber-jvm/pull/1494):
"We're still on java 7 until v4 is done so it should be 7. Please fix in parent."