### PR TITLE
Use Maven defaults for Jacoco and Surefire

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
 
     <groupId>io.cucumber</groupId>
@@ -67,16 +68,6 @@
     </distributionManagement>
 
     <profiles>
-        <profile>
-            <id>test</id>
-            <properties>
-                <env>test</env>
-                <gebEnv>test</gebEnv>
-                <jacoco.skip>false</jacoco.skip>
-                <maven.test.skip>false</maven.test.skip>
-                <skip.unit.tests>false</skip.unit.tests>
-            </properties>
-        </profile>
         <profile>
             <id>sign-source-javadoc</id>
             <build>
@@ -170,16 +161,6 @@
             </build>
         </profile>
     </profiles>
-
-    <reporting>
-        <plugins>
-            <plugin>
-                <groupId>org.jacoco</groupId>
-                <artifactId>jacoco-maven-plugin</artifactId>
-                <version>${jacoco-maven-plugin.version}</version>
-            </plugin>
-        </plugins>
-    </reporting>
 
     <build>
         <!--
@@ -318,14 +299,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.1</version>
-                    <configuration>
-                        <argLine>-Duser.language=en</argLine>
-                        <argLine>-Xmx1024m</argLine>
-                        <argLine>-XX:MaxPermSize=256m</argLine>
-                        <argLine>-Dfile.encoding=UTF-8</argLine>
-                        <argLine>${surefireArgLine}</argLine>
-                        <useFile>false</useFile>
-                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -338,44 +311,6 @@
                     <groupId>org.jacoco</groupId>
                     <artifactId>jacoco-maven-plugin</artifactId>
                     <version>${jacoco-maven-plugin.version}</version>
-                    <executions>
-                        <!--
-                            Prepares the property pointing to the JaCoCo runtime agent which
-                            is passed as VM argument when Maven the Surefire plugin is executed.
-                        -->
-                        <execution>
-                            <id>pre-unit-test</id>
-                            <goals>
-                                <goal>prepare-agent</goal>
-                            </goals>
-                            <configuration>
-                                <!-- Sets the path to the file which contains the execution data. -->
-                                <destFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</destFile>
-                                <!--
-                                    Sets the name of the property containing the settings
-                                    for JaCoCo runtime agent.
-                                -->
-                                <propertyName>surefireArgLine</propertyName>
-                            </configuration>
-                        </execution>
-                        <!--
-                            Ensures that the code coverage report for unit tests is created after
-                            unit tests have been run.
-                        -->
-                        <execution>
-                            <id>post-unit-test</id>
-                            <phase>test</phase>
-                            <goals>
-                                <goal>report</goal>
-                            </goals>
-                            <configuration>
-                                <!-- Sets the path to the file which contains the execution data. -->
-                                <dataFile>${project.build.directory}/coverage-reports/jacoco-ut.exec</dataFile>
-                                <!-- Sets the output directory for the code coverage report. -->
-                                <outputDirectory>${project.reporting.outputDirectory}/jacoco-ut</outputDirectory>
-                            </configuration>
-                        </execution>
-                    </executions>
                 </plugin>
 
                 <plugin>


### PR DESCRIPTION
Maven works best when no customization is applied. This allows entire
eco system to work using 'well known' values which in turn reduces
configuration.

The existing configuration was primarily reconfiguring the defaults or
renaming them for no apparent reason.

Running jacoco now is as simple as:

```
mvn clean jacoco:prepare-agent test jacoco:report
```

And reporting in multi-module projects:

```
mvn clean jacoco:prepare-agent test jacoco:report-aggregate
```

Or with integration tests

```
mvn clean jacoco:prepare-agent jacoco:prepare-integration verify jacoco:report
```

If this becomes common in all modules we can add a profile for it to
the parent pom but not until then.