### PR TITLE
cucumber-parent: multi-release jar for jpms

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <groupId>io.cucumber</groupId>
     <artifactId>cucumber-parent</artifactId>
-    <version>2.0.3-SNAPSHOT</version>
+    <version>3.0.0-SNAPSHOT</version>
     <packaging>pom</packaging>
     <name>Cucumber Parent</name>
     <description>Common configuration for all Cucumber modules</description>
@@ -21,12 +21,19 @@
     </developers>
 
     <properties>
-        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
         <outputDirectory>${project.build.directory}</outputDirectory>
         <minimum.maven.version>3.6.0</minimum.maven.version>
         <jacoco-maven-plugin.version>0.8.4</jacoco-maven-plugin.version>
         <java.version>1.8</java.version>
+        <maven.javadoc.source>${java.version}</maven.javadoc.source>
+        <maven.compiler.source>${java.version}</maven.compiler.source>
+        <maven.compiler.target>${java.version}</maven.compiler.target>
+        <encoding.default>UTF-8</encoding.default>
+        <project.build.sourceEncoding>${encoding.default}</project.build.sourceEncoding>
+        <project.build.outputEncoding>${encoding.default}</project.build.outputEncoding>
+        <project.reporting.outputEncoding>${encoding.default}</project.reporting.outputEncoding>
+        <toolchain.vendor>openjdk</toolchain.vendor>
+        <toolchain.base.java.version>1.8</toolchain.base.java.version>
     </properties>
 
     <licenses>
@@ -41,7 +48,6 @@
         <connection>scm:git:git://github.com/cucumber/cucumber-parent.git</connection>
         <developerConnection>scm:git:git@github.com:cucumber/cucumber-parent.git</developerConnection>
         <url>git://github.com/cucumber/cucumber-parent.git</url>
-        <tag>HEAD</tag>
     </scm>
 
     <!--
@@ -67,6 +73,15 @@
     </distributionManagement>
 
     <profiles>
+        <profile>
+            <id>java11</id>
+            <activation>
+                <jdk>[11,)</jdk>
+            </activation>
+            <properties>
+                <toolchain.base.java.version>11</toolchain.base.java.version>
+            </properties>
+        </profile>
         <profile>
             <id>sign-source-javadoc</id>
             <build>
@@ -180,11 +195,26 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-compiler-plugin</artifactId>
                     <version>3.8.1</version>
-                    <configuration>
-                        <encoding>UTF-8</encoding>
-                        <source>${java.version}</source>
-                        <target>${java.version}</target>
-                    </configuration>
+                    <executions>
+                        <execution>
+                            <id>java11</id>
+                            <phase>compile</phase>
+                            <goals>
+                                <goal>compile</goal>
+                            </goals>
+                            <configuration>
+                                <release>11</release>
+                                <jdkToolchain>
+                                    <version>11</version>
+                                </jdkToolchain>
+                                <compileSourceRoots>
+                                    <compileSourceRoot>${project.basedir}/src/main/java</compileSourceRoot>
+                                    <compileSourceRoot>${project.basedir}/src/main/java11</compileSourceRoot>
+                                </compileSourceRoots>
+                                <multiReleaseOutput>true</multiReleaseOutput>
+                            </configuration>
+                        </execution>
+                    </executions>
                 </plugin>
 
                 <plugin>
@@ -236,7 +266,7 @@
                     <version>3.1.1</version>
                     <configuration>
                         <use>false</use>
-                        <source>1.8</source>
+                        <source>${maven.javadoc.source}</source>
                         <links>
                             <link>https://docs.oracle.com/javase/8/docs/api/</link>
                         </links>
@@ -252,8 +282,12 @@
                         <archive>
                             <manifestEntries>
                                 <Automatic-Module-Name>${project.Automatic-Module-Name}</Automatic-Module-Name>
+                                <Multi-Release>true</Multi-Release>
                             </manifestEntries>
                         </archive>
+                        <excludes>
+                            <exclude>**/ModuleInfoHack.class</exclude>
+                        </excludes>
                     </configuration>
                 </plugin>
 
@@ -298,6 +332,27 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>2.22.1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-toolchains-plugin</artifactId>
+                    <version>1.1</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>toolchain</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <toolchains>
+                            <jdk>
+                                <version>${toolchain.base.java.version}</version>
+                                <vendor>${toolchain.vendor}</vendor>
+                            </jdk>
+                        </toolchains>
+                    </configuration>
                 </plugin>
 
                 <plugin>
@@ -392,6 +447,11 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
+            </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-toolchains-plugin</artifactId>
             </plugin>
 
             <plugin>


### PR DESCRIPTION
I've been working with this pom setup for about a month now. I've got cucumber-expressions, datatable, gherkin and tag-expressions branches all building with it dual support java 1.8 and 11 jars, and cucumber-jvm:5.0.0-SNAPSHOT depending upon those versions. I don't believe I'll need to change this pom to fix any build or test issues with downstream modules so want to release this so i can move on with cucumber jpms.

Some version properties have changes and so has some encoding values.

Things like ModuleInfoHack have been needed when created shaded/bundles of dependencies so the compiler doesn't fail the build as that pom doesn't contain any packages as described in modules-info.java.