### PR TITLE
Add manifest entries to make clazz.getPackage().getImplementationVersion() work

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -250,6 +250,10 @@
                     <version>3.2.0</version>
                     <configuration>
                         <archive>
+                            <manifest>
+                                <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+                                <addDefaultSpecificationEntries>true</addDefaultSpecificationEntries>
+                            </manifest>
                             <manifestEntries>
                                 <Automatic-Module-Name>${project.Automatic-Module-Name}</Automatic-Module-Name>
                             </manifestEntries>


### PR DESCRIPTION
This is needed for https://github.com/cucumber/cucumber/pull/976