### PR TITLE
Watch release from make release

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,4 +39,5 @@ update-major-dependency-versions:
 release:
 	mvn --batch-mode release:clean release:prepare -DautoVersionSubmodules=true -Darguments="-DskipTests=true -DskipITs=true -Darchetype.test.skip=true"
 	git push origin $$(git rev-list --max-count=1 v$(NEW_VERSION)):refs/heads/release/v$(NEW_VERSION)
+	gh run watch `gh run list -b release/v$(NEW_VERSION) --json databaseId -q '.[].databaseId'`
 .PHONY: release

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -55,7 +55,8 @@ Only people with permission to push to release/* branches can make releases.
 
     make release
 
-3. Wait until the `release-*` workflows in GitHub Actions have passed
+This will wait until the release workflows in GitHub Actions have passed.
+
 4. Announce the release
    * in the `#newsletter` Slack channel
    * on the `@cucumberbdd` Twitter account


### PR DESCRIPTION
### 🤔 What's changed?

The `make release` command should now wait for the release to complete, using the `gh` command to watch the GitHub Actions run from the command-line.

### ⚡️ What's your motivation? 

Automate one more step in the release process.

### 🏷️ What kind of change is this?

<!--- Delete any options that are not relevant -->

- :bank: Refactoring/debt/DX (improvement to code design, tooling, documentation etc. without changing behaviour)

### ♻️ Anything particular you want feedback on?

We need to test it to see if it actually works. Perhaps best to merge this in when we want to next make a release, or to use in in the Cucumber-JVM release automation first.

### 📋 Checklist:

<!--- 
This is to help you remember all the little things we often forget to do!

Feel free to delete any tasks that are not relevant, or add new ones.
-->

- [x] I agree to respect and uphold the [Cucumber Community Code of Conduct](https://cucumber.io/conduct/)
- [ ] I've changed the behaviour of the code
  - [ ] I have added/updated tests to cover my changes.
- [ ] My change requires a change to the documentation.
  - [ ] I have updated the documentation accordingly.
- [ ] Users should know about my change
  - [ ] I have added an entry to the "Unreleased" section of the [**CHANGELOG**](../CHANGELOG.md), linking to this pull request.

----

*This text was originally generated from a [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/about-issue-and-pull-request-templates), then edited by hand. [You can modify the template here.](https://github.com/cucumber/.github/edit/main/.github/PULL_REQUEST_TEMPLATE.md)*
